### PR TITLE
prevent endless loop if lineNumber is negative

### DIFF
--- a/src/rules/indentation.coffee
+++ b/src/rules/indentation.coffee
@@ -116,6 +116,7 @@ module.exports = class Indentation
 
     grabLineTokens: (tokenApi, lineNumber, all = false) ->
         { tokensByLine } = tokenApi
+        lineNumber = 0 if lineNumber < 0
         lineNumber-- until tokensByLine[lineNumber]? or lineNumber is 0
 
         if all


### PR DESCRIPTION
example code that hangs the browser tab on http://www.coffeelint.org:
```coffee
###
  test
```