### PR TITLE
CSVReporter: Properly double quote field

### DIFF
--- a/src/reporters/csv.coffee
+++ b/src/reporters/csv.coffee
@@ -15,12 +15,12 @@ module.exports = class CSVReporter
             for e in errors when not @quiet or e.level is 'error'
                 # Having the context is useful for the cyclomatic_complexity
                 # rule and critical for the undefined_variables rule.
-                e.message += " #{e.context}." if e.context
+                e.message += " #{e.context}" if e.context
                 f = [
                     path
                     e.lineNumber
                     e.lineNumberEnd ? e.lineNumberEnd
                     e.level
-                    e.message
+                    '"' + e.message.replace(/\"/g, '""') + '"'
                 ]
                 @print f.join(',')


### PR DESCRIPTION
https://github.com/clutchski/coffeelint/pull/514

Follows this http://tools.ietf.org/html/rfc4180 in regards to using
double quotes around fields that can have commas or spaces, as well as
using two quotes ("") to escape inside a field's value

Closes https://github.com/clutchski/coffeelint/issues/298