### PR TITLE
colon_assignment_spacing: add opt. properties min_left, min_right

### DIFF
--- a/test/test_colon_assignment_spacing.coffee
+++ b/test/test_colon_assignment_spacing.coffee
@@ -155,4 +155,34 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source, config)
             assert.lengthOf(errors, 2)
 
+    'Should ignore exact specification in case of minimum spacing':
+        topic:
+            '''
+            object = {spacing: true}
+            object =
+              spacing: true
+            object =
+              spacing : true
+            object =
+              spacing:  true
+            object =
+              spacing    :    true
+            class Dog
+              barks: true
+            stringyObject =
+              'stringkey': 'ok'
+            '''
+
+        'will return an error': (source) ->
+            config =
+                colon_assignment_spacing:
+                    level: 'error'
+                    spacing:
+                        left: 1
+                        right: 1
+                        min_left: 0
+                        min_right: 1
+            errors = coffeelint.lint(source, config)
+            assert.isEmpty(errors)
+
 }).export(module)


### PR DESCRIPTION
https://github.com/clutchski/coffeelint/pull/594

Usage:

```coffeescript
    spacing:
        min_left: 1
        min_right: 2
```

This means that the space to the left of the assignment-colon has to be at
least 1 whitespace; and the space to the right of the assignment-colon has to
be at least 2 whitespaces.

The `left` and `right` are ignored if `min_left` and `min_right` are
non-negative. By default, `min_left` and `min_right` are ignored as they are
set to `-1` by default.

Also, the code of the rule was simplified. And finally, a test case was added
as well.