### PR TITLE
fix newlines_after_classes when last class line has blank lines before it

### DIFF
--- a/src/rules/newlines_after_classes.coffee
+++ b/src/rules/newlines_after_classes.coffee
@@ -34,34 +34,24 @@ module.exports = class NewlinesAfterClasses
                 @classBracesCount--
                 @classCount--
                 if @classCount is 0 and @classBracesCount is 0
-                    befores = 1
                     afters = 1
                     comment = 0
                     outdent = token.origin[2].first_line
                     start = Math.min(lineNumber, outdent)
-                    trueLine = Infinity
+                    trueLine = start + 1
 
                     while (/^\s*(#|$)/.test(lines[start + afters]))
                         if /^\s*#/.test(lines[start + afters])
                             comment += 1
-                        else
-                            trueLine = Math.min(trueLine, start + afters)
                         afters += 1
-
-                    while (/^\s*(#|$)/.test(lines[start - befores]))
-                        if /^\s*#/.test(lines[start - befores])
-                            comment += 1
-                        else
-                            trueLine = Math.min(trueLine, start - befores)
-                        befores += 1
 
                     # add up blank lines, subtract comments, subtract 2 because
                     # before/after counters started at 1.
-                    got = afters + befores - comment - 2
+                    got = afters - comment - 1
 
                     # if `got` and `ending` don't match throw an error _unless_
                     # we are at the end of the file.
-                    if got isnt ending and trueLine + ending <= lines.length
+                    if got isnt ending and trueLine + got isnt lines.length
                         return {
                             context: "Expected #{ending} got #{got}"
                             lineNumber: trueLine

--- a/test/test_newlines_after_classes.coffee
+++ b/test/test_newlines_after_classes.coffee
@@ -388,4 +388,56 @@ vows.describe(RULE).addBatch({
             assert.equal(errors[0].rule, RULE)
             assert.equal(errors[0].context, 'Expected 3 got 1')
 
+    'Fix #28, empty lines inside class should not count':
+        topic:
+            '''
+            class TestClass
+              constructor: ->
+                @locked = true
+                @count = 0
+
+              increment: ->
+                return if @locked
+
+
+                count += 1
+
+            console.log 1
+            '''
+
+        'passes when newlines_after_classes is set to 1': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 1
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 0)
+
+        'fails when newlines_after_classes is set to 2': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 2
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 11)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, RULE)
+            assert.equal(errors[0].context, 'Expected 2 got 1')
+
+        'fails when newlines_after_classes is set to 3': (source) ->
+            config =
+                newlines_after_classes:
+                    level: 'error'
+                    value: 3
+
+            errors = coffeelint.lint(source, config)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 11)
+            assert.equal(errors[0].line, '')
+            assert.equal(errors[0].rule, RULE)
+            assert.equal(errors[0].context, 'Expected 3 got 1')
+
 }).export(module)


### PR DESCRIPTION
fix newlines_after_classes when last class line has blank lines before it.

fixes #28 
