### PR TITLE
fix last line comment trailing semicolon

### DIFF
--- a/src/rules/no_trailing_semicolons.coffee
+++ b/src/rules/no_trailing_semicolons.coffee
@@ -33,6 +33,9 @@ module.exports = class NoTrailingSemicolons
         if tokenLen is 1 and lineTokens[0][0] in stopTokens
             return
 
+        if tokenLen is 2 and lineTokens[1].generated and lineTokens[0][0] in stopTokens
+            return
+
         newLine = line
         if tokenLen > 1 and lineTokens[tokenLen - 1][0] is 'TERMINATOR'
 

--- a/test/test_no_trailing_semicolons.coffee
+++ b/test/test_no_trailing_semicolons.coffee
@@ -66,6 +66,16 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source, {})
             assert.isEmpty(errors)
 
+    'Trailing semicolon in last line comment':
+        topic:
+            '''
+            undefined\n# comment;
+            '''
+
+        'are ignored': (source) ->
+            errors = coffeelint.lint(source, {})
+            assert.isEmpty(errors)
+
     'Trailing semicolon in comments with no semicolon in statement':
         topic:
             '''


### PR DESCRIPTION
Fix comment with trailing semicolon on the last line.

```coffee
undefined
# comment;
```

fixes #54