### PR TITLE
fix: Improve max_line_length rule with comment behavior

### DIFF
--- a/src/rules/max_line_length.coffee
+++ b/src/rules/max_line_length.coffee
@@ -1,12 +1,12 @@
 regexes =
     literateComment: ///
-        ^
-        \#\s # This is prefixed on MarkDown lines.
+        ^\s*\#\s # indentation, up to comment followed by at least one space.
     ///
     longUrlComment: ///
-      ^\s*\# # indentation, up to comment
-      \s*
-      http[^\s]+$ # Link that takes up the rest of the line without spaces.
+      ^\s*\#\s # indentation, up to comment followed by at least one space.
+      .* # Any string may precedes url
+      http[^\s]+ # Actual link
+      .*$ # Line may end by other things
     ///
 
 module.exports = class MaxLineLength

--- a/test/test_max_line_length.coffee
+++ b/test/test_max_line_length.coffee
@@ -80,4 +80,32 @@ vows.describe(RULE).addBatch({
             errors = coffeelint.lint(source)
             assert.isEmpty(errors)
 
+    'Indented comment':
+        topic:
+            # This test text should never generate an error on the URL
+            # line. Instead, it should only report an error on line 2,
+            # unless errors are desactivated in comments.
+            # These tests work with the default line length limit of 80
+            # chars and the default indent size of 2.
+            '''
+            class Test
+              # Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras porta lacinia elementum.
+              # @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch fetch API on mozdev
+              request: (opts) ->
+                doSomething()
+            '''
+
+        'report error in comment by default, but ignore url': (source) ->
+            errors = coffeelint.lint(source)
+            assert.equal(errors.length, 1)
+            assert.equal(errors[0].lineNumber, 2)
+
+        'can ignore comments': (source) ->
+            config =
+                max_line_length:
+                    limitComments: false
+
+            errors = coffeelint.lint(source, config)
+            assert.isEmpty(errors)
+
 }).export(module)

--- a/test/test_max_line_length.coffee
+++ b/test/test_max_line_length.coffee
@@ -81,19 +81,26 @@ vows.describe(RULE).addBatch({
             assert.isEmpty(errors)
 
     'Indented comment':
-        topic:
+        topic: ->
             # This test text should never generate an error on the URL
             # line. Instead, it should only report an error on line 2,
             # unless errors are desactivated in comments.
             # These tests work with the default line length limit of 80
             # chars and the default indent size of 2.
-            '''
+            text = '''
             class Test
-              # Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras porta lacinia elementum.
+              # Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               # @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch fetch API on mozdev
               request: (opts) ->
                 doSomething()
             '''
+            text_lines = text.split('\n')
+            # Artificially augment the second line. We do that this way
+            # to avoid a lint error in this project itself when reading
+            # the text above, as the project config doesn't allow long
+            # line in comments.
+            text_lines[1] += ' Cras porta lacinia elementum.'
+            text_lines.join('\n')
 
         'report error in comment by default, but ignore url': (source) ->
             errors = coffeelint.lint(source)


### PR DESCRIPTION
The current `max_line_length` will report annoying error on this kind of comment:

```coffee
class Test
  # Build ajax request with some default options.
  #
  # @private
  #
  # @param opts [Object] Fetch API init object with some very long comment line olalala
  # @see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch fetch API on mozdev
  _request: (opts) ->
    doSomething
```

With the current implementation, coffeelint will report an error on both line 6 (`@param opts…`) and 7 (`@see…`).

This rule should, IMHO only report line 6 with `"limitComments": true` and nothing with `"limitComments": false`.

This MR fix the two inner regexps to follow the spec above.