### PR TITLE
ci: add node 12 to workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node_version: [10.x, 'lts/*', node]
+        node_version: [10.x, 12.x, 'lts/*', node]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Node 14 is the recent LTS since oct 27.