### PR TITLE
Resolve package name properly

### DIFF
--- a/bin/coffeelint
+++ b/bin/coffeelint
@@ -26,7 +26,7 @@ if (!existsFn(commandline)) {
     try {
         // Try to find a project-specific install first. This works the same
         // way grunt-cli does.
-        filepath = resolve('coffeelint', { basedir: process.cwd() });
+        filepath = resolve('@coffeelint/cli', { basedir: process.cwd() });
         commandline = path.dirname(filepath) + path.sep + 'commandline.js';
     } catch (ex) {
     }


### PR DESCRIPTION
## Problem statement 

Currently, in our project we have 2 codebases that use CoffeeScript. Oddly enough, the oldest part uses CoffeeScript 1, while the newest - CoffeeScript 2. Both of these codebases were linted using [`coffeelint`](https://github.com/clutchski/coffeelint).

A problem has arisen when we tried to use Webpack's `import()` syntax, which worked for CoffeeScript, but not for the our old `coffeelint`. 

To solve this, we tried to update the library and use `@coffeelint/cli`.
That's when we discovered that, although this package (`@coffeelint/cli`) and `coffeelint` can co-exist (each with its own dependencies), the `node_modules/@coffeelint/cli/bin/coffeelint` binary still resolves to the old `coffeelint` package, and not to the `@coffeelint/cli`. With this setup, the linter uses old `coffee-script` package (a dependency of `coffeelint`).

## Steps to reproduce

1. create a test file
```coffee
# inside sample.coffee
import("./some_package")
```

2. add 2 packages - old and new coffeelint
```
yarn add -D coffeelint # install old coffeelint
yarn add -D @coffeelint/cli # install new coffeelint
```

3. run checks using old coffeelint
```
node_modules/coffeelint/bin/coffeelint sample.coffee 
 ✗ sample.coffee
     ✗ #1: [stdin]:1:7: error: unexpected (
import("./other")
      ^.

✗ Lint! » 1 error and 0 warnings in 1 file
```

4. run checks using new coffeelint

```
node_modules/@coffeelint/cli/bin/coffeelint sample.coffee 
 ✗ sample.coffee
     ✗ #1: [stdin]:1:7: error: unexpected (
import("./other")
      ^.

✗ Lint! » 1 error and 0 warnings in 1 file
```

5. remove old coffelint
```
yarn remove coffeelint
```

6. run new coffeelint
```
node_modules/@coffeelint/cli/bin/coffeelint sample.coffee
  ✓ sample.coffee

✓ Ok! » 0 errors and 0 warnings in 1 file
```

## Solution

Changed the resolved package name in `bin/coffeelint`, to resolve to `@coffeelint/cli`.